### PR TITLE
New MySQL view behaviour for stretch guests

### DIFF
--- a/mws/apimws/tests/test_bes.py
+++ b/mws/apimws/tests/test_bes.py
@@ -10,7 +10,7 @@ from sitesmanagement.tests.tests import assign_a_site
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class BesTests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
     def setUp(self):
         do_test_login(self, user="test0001")
         assign_a_site(self)

--- a/mws/apimws/tests/test_dns.py
+++ b/mws/apimws/tests/test_dns.py
@@ -13,7 +13,7 @@ from sitesmanagement.tests.tests import assign_a_site
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class DNSTests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
     def setUp(self):
         do_test_login(self, user="test0001")
         assign_a_site(self)

--- a/mws/apimws/tests/test_snapshots.py
+++ b/mws/apimws/tests/test_snapshots.py
@@ -12,7 +12,7 @@ from sitesmanagement.tests.tests import assign_a_site
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class SnapshotsTests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
     def setUp(self):
         do_test_login(self, user="test0001")
         assign_a_site(self)

--- a/mws/apimws/tests/test_vmapi.py
+++ b/mws/apimws/tests/test_vmapi.py
@@ -12,7 +12,7 @@ from apimws.xen import change_vm_power_state, reset_vm, destroy_vm, clone_vm_api
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class XenAPITests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
 
     def setUp(self):
         do_test_login(self, "test0001")

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -72,6 +72,6 @@ EMAIL_TIMEOUT = 60
 IP_REG_API_END_POINT = IP_REG_API_END_POINT + ['dev']
 
 OS_VERSION_VMXENAPI = "stretch"
-OS_DUE_UPGRADE = []
+OS_DUE_UPGRADE = ["jessie"]
 
 from mws.logging_configuration import *

--- a/mws/sitesmanagement/tests/test_admin_suspended.py
+++ b/mws/sitesmanagement/tests/test_admin_suspended.py
@@ -10,7 +10,7 @@ from sitesmanagement.tests.tests import assign_a_site
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class AdminSuspendedTests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
     def setUp(self):
         do_test_login(self, user="test0001")
         assign_a_site(self)

--- a/mws/sitesmanagement/tests/test_vhosts.py
+++ b/mws/sitesmanagement/tests/test_vhosts.py
@@ -9,7 +9,7 @@ from sitesmanagement.tests.tests import assign_a_site
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class VhostTests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
     def setUp(self):
         do_test_login(self, user="test0001")
         assign_a_site(self)

--- a/mws/sitesmanagement/tests/tests.py
+++ b/mws/sitesmanagement/tests/tests.py
@@ -682,6 +682,32 @@ class SiteManagement2Tests(TestCase):
                     </tr>
                 </tbody>''', response.content, count=1)
 
+    def test_root_pwd_message(self):
+        site = self.create_site()
+
+        # Test Jessie response
+        AnsibleConfiguration.objects.update_or_create(service=site.production_service, key='os',
+                                                      defaults={'value': 'jessie'})
+        response = self.client.get(reverse('sitesmanagement.views.service_settings',
+                                           kwargs={'service_id': site.production_service.id}))
+        self.assertContains(response=response, text="Change database root password")
+        response = self.client.get(reverse('change_db_root_password',
+                                           kwargs={'service_id': site.production_service.id}))
+        self.assertEqual(response.status_code, 200)
+
+        # Test Stretch response
+        AnsibleConfiguration.objects.update_or_create(service=site.production_service, key='os',
+                                                      defaults={'value': 'stretch'})
+        response = self.client.get(reverse('sitesmanagement.views.service_settings',
+                                           kwargs={'service_id': site.production_service.id}))
+        self.assertContains(response=response, text="Root database passwords no longer apply to your version of the "
+                                                    "Operation System, for more information, please read the MWS "
+                                                    "documentation")
+        response = self.client.get(reverse('change_db_root_password',
+                                           kwargs={'service_id': site.production_service.id}))
+        self.assertRedirects(response=response, expected_url=reverse(site))
+
+
     # def test_certificates(self):
     #     site = self.create_site()
     #

--- a/mws/sitesmanagement/tests/tests.py
+++ b/mws/sitesmanagement/tests/tests.py
@@ -700,12 +700,11 @@ class SiteManagement2Tests(TestCase):
                                                       defaults={'value': 'stretch'})
         response = self.client.get(reverse('sitesmanagement.views.service_settings',
                                            kwargs={'service_id': site.production_service.id}))
-        self.assertContains(response=response, text="Root database passwords no longer apply to your version of the "
-                                                    "Operation System, for more information, please read the MWS "
-                                                    "documentation")
+        self.assertContains(response=response, text="""Root database passwords no longer apply to your version of the Operation
+                                            System, for more information, please read the MWS documentation""")
         response = self.client.get(reverse('change_db_root_password',
                                            kwargs={'service_id': site.production_service.id}))
-        self.assertRedirects(response=response, expected_url=reverse(site))
+        self.assertRedirects(response=response, expected_url=reverse('showsite', args=[str(site.id)]))
 
 
     # def test_certificates(self):

--- a/mws/sitesmanagement/tests/tests.py
+++ b/mws/sitesmanagement/tests/tests.py
@@ -117,7 +117,7 @@ def assign_a_site(test_interface, pre_create=True):
 
 @override_settings(CELERY_EAGER_PROPAGATES_EXCEPTIONS=True, CELERY_ALWAYS_EAGER=True, BROKER_BACKEND='memory')
 class SiteManagementTests(TestCase):
-    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/amc203_test_IPs.yaml'), ]
+    fixtures = [os.path.join(settings.BASE_DIR, 'sitesmanagement/fixtures/network_configuration_dev.yaml'), ]
 
     def test_is_camacuk_helper(self):
         self.assertTrue(is_camacuk("www.cam.ac.uk"))

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -125,13 +125,10 @@ def service_settings(request, service_id):
                 url=reverse(service_settings, kwargs={'service_id': service.id}))
     }
 
-    service_conf = AnsibleConfiguration.objects.filter(service=service, key='os')
-
     return render(request, 'mws/settings.html', {
         'breadcrumbs': breadcrumbs,
         'site': site,
         'service': service,
-        'os': service_conf[0].value if service_conf else None,
         'sidebar_messages': warning_messages(site),
     })
 
@@ -202,9 +199,7 @@ def change_db_root_password(request, service_id):
     if site is None:
         return HttpResponseForbidden()
 
-    service_conf = AnsibleConfiguration.objects.filter(service=service, key='os')
-
-    if (service_conf is not None and service_conf[0].value == 'stretch') \
+    if (service.operating_system == 'stretch') \
             or not service or not service.active or service.is_busy:
         return redirect(site)
 

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -131,7 +131,7 @@ def service_settings(request, service_id):
         'breadcrumbs': breadcrumbs,
         'site': site,
         'service': service,
-        'os': service_conf.value if service_conf else None,
+        'os': service_conf[0].value if service_conf else None,
         'sidebar_messages': warning_messages(site),
     })
 

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -204,7 +204,8 @@ def change_db_root_password(request, service_id):
 
     service_conf = AnsibleConfiguration.objects.filter(service=service, key='os')
 
-    if (service_conf and service_conf.value == 'stretch') or not service or not service.active or service.is_busy:
+    if (service_conf is not None and service_conf[0].value == 'stretch') \
+            or not service or not service.active or service.is_busy:
         return redirect(site)
 
     breadcrumbs = {

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -125,10 +125,13 @@ def service_settings(request, service_id):
                 url=reverse(service_settings, kwargs={'service_id': service.id}))
     }
 
+    service_conf = AnsibleConfiguration.objects.filter(service=service, key='os')
+
     return render(request, 'mws/settings.html', {
         'breadcrumbs': breadcrumbs,
         'site': site,
         'service': service,
+        'os': service_conf.value if service_conf else None,
         'sidebar_messages': warning_messages(site),
     })
 
@@ -199,7 +202,9 @@ def change_db_root_password(request, service_id):
     if site is None:
         return HttpResponseForbidden()
 
-    if not service or not service.active or service.is_busy:
+    service_conf = AnsibleConfiguration.objects.filter(service=service, key='os')
+
+    if (service_conf and service_conf.value == 'stretch') or not service or not service.active or service.is_busy:
         return redirect(site)
 
     breadcrumbs = {

--- a/mws/templates/mws/settings.html
+++ b/mws/templates/mws/settings.html
@@ -149,7 +149,8 @@
 
             <div class="campl-column3">
                 <div class="campl-content-container campl-side-padding">
-                    <a href="{% url 'change_db_root_password' service_id=service.id %}">
+                    <a href="{% if os == 'stretch' %}https://mws-help.uis.cam.ac.uk/provided-software/mysql{%
+                            else %}{% url 'change_db_root_password' service_id=service.id %}{% endif %}">
                         <article class="node node-external-link view-mode-focus_on clearfix
                                         campl-horizontal-teaser campl-teaser campl-focus-teaser">
                             <div class="campl-focus-teaser-img">
@@ -168,7 +169,14 @@
                             </div>
                             <div class="campl-focus-teaser-txt">
                                 <div class="campl-content-container campl-horizontal-teaser-txt">
-                                    <h3 class="campl-teaser-title">Change database root password</h3>
+                                    <h3 class="campl-teaser-title">
+                                        {% if os == 'stretch' %}
+                                            Root database passwords no longer apply to your version of the Operation
+                                            System, for more information, please read the MWS documentation
+                                        {% else %}
+                                            Change database root password
+                                        {% endif %}
+                                    </h3>
                                     <span class="ir campl-focus-link"></span>
                                 </div>
                             </div>

--- a/mws/templates/mws/settings.html
+++ b/mws/templates/mws/settings.html
@@ -147,6 +147,7 @@
             </div>
             {% endif %}
 
+            {% with service.operating_system as os %}
             <div class="campl-column3">
                 <div class="campl-content-container campl-side-padding">
                     <a href="{% if os == 'stretch' %}https://mws-help.uis.cam.ac.uk/provided-software/mysql{%
@@ -184,6 +185,7 @@
                     </a>
                 </div>
             </div>
+            {% endwith %}
 
         {% if service.primary %}
             <div class="campl-column3">


### PR DESCRIPTION
It should't allow to change root mysql password as in stretch because users are added as mysql admins and have all permisions granted.
- New screen for stretch based VMs redirects to mws documentation.
- Change db root pwd view redirects to the main panel if user tries to access anyway.
- No changes for jessie based VMs.