### PR TITLE
remove unused argument

### DIFF
--- a/mws/apimws/management/commands/store_tls_files.py
+++ b/mws/apimws/management/commands/store_tls_files.py
@@ -12,10 +12,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('vhost_id', type=str)
-        parser.add_argument('hash', type=str)
 
     def handle(self, *args, **options):
-        # FIXME: hash appears to be ignored
         try:
             vhost = Vhost.objects.get(id=options['vhost_id'])
         except Vhost.DoesNotExist:


### PR DESCRIPTION
mws-ansible/roles/mwsclient/tasks/tlscerts.yml expects only the vhost_id, so don't require the hash as we're not using it here anyway.