### PR TITLE
replace OS_VERSION_VMXENAPI with OS_VERSION

### DIFF
--- a/mws/apimws/xen.py
+++ b/mws/apimws/xen.py
@@ -105,7 +105,7 @@ def secrets_prealocation_vm(vm):
 def new_site_primary_vm(service, host_network_configuration=None):
     parameters = {}
     parameters["site-id"] = "mwssite-%d" % service.site.id
-    parameters["os"] = getattr(settings, 'OS_VERSION_VMXENAPI', "jessie")
+    parameters["os"] = getattr(settings, 'OS_VERSION', "jessie")
 
     if host_network_configuration:
         netconf = {}
@@ -157,7 +157,7 @@ def new_site_primary_vm(service, host_network_configuration=None):
     from apimws.models import AnsibleConfiguration
     AnsibleConfiguration.objects.update_or_create(service=service, key='os',
                                                   defaults={'value': getattr(settings,
-                                                                             "OS_VERSION_VMXENAPI", "jessie")})
+                                                                             "OS_VERSION", "jessie")})
 
     # Create a default Vhost and associate the service name
     default_vhost = Vhost.objects.create(service=service, name="default")
@@ -261,7 +261,7 @@ def clone_vm_api_call(site):
     host_network_configuration = NetworkConfig.get_free_host_config()
     parameters = {}
     parameters["site-id"] = "mwssite-%d" % service.site.id
-    parameters["os"] = getattr(settings, 'OS_VERSION_VMXENAPI', "jessie")
+    parameters["os"] = getattr(settings, 'OS_VERSION', "jessie")
 
     if host_network_configuration:
         netconf = {}
@@ -307,7 +307,7 @@ def clone_vm_api_call(site):
     from apimws.models import AnsibleConfiguration
     AnsibleConfiguration.objects.update_or_create(service=service, key='os',
                                                   defaults={'value': getattr(settings,
-                                                                             "OS_VERSION_VMXENAPI", "jessie")})
+                                                                             "OS_VERSION", "jessie")})
     secrets_prealocation_vm(vm)
 
     # PHPLibs

--- a/mws/apimws/xen_mock.py
+++ b/mws/apimws/xen_mock.py
@@ -51,7 +51,7 @@ def secrets_prealocation_vm(vm):
 def new_site_primary_vm(service, host_network_configuration=None):
     parameters = {}
     parameters["site-id"] = "mwssite-%d" % service.site.id
-    parameters["os"] = getattr(settings, 'OS_VERSION_VMXENAPI', "jessie")
+    parameters["os"] = getattr(settings, 'OS_VERSION', "jessie")
 
     if host_network_configuration:
         netconf = {}
@@ -87,7 +87,7 @@ def new_site_primary_vm(service, host_network_configuration=None):
     from apimws.models import AnsibleConfiguration
     AnsibleConfiguration.objects.update_or_create(service=service, key='os',
                                                   defaults={'value': getattr(settings,
-                                                                             "OS_VERSION_VMXENAPI", "jessie")})
+                                                                             "OS_VERSION", "jessie")})
 
     # Create a default Vhost and associate the service name
     default_vhost = Vhost.objects.create(service=service, name="default")
@@ -111,7 +111,7 @@ def clone_vm_api_call(site):
     host_network_configuration = NetworkConfig.get_free_host_config()
     parameters = {}
     parameters["site-id"] = "mwssite-%d" % service.site.id
-    parameters["os"] = getattr(settings, 'OS_VERSION_VMXENAPI', "jessie")
+    parameters["os"] = getattr(settings, 'OS_VERSION', "jessie")
 
     if host_network_configuration:
         netconf = {}
@@ -141,7 +141,7 @@ def clone_vm_api_call(site):
     from apimws.models import AnsibleConfiguration
     AnsibleConfiguration.objects.update_or_create(service=service, key='os',
                                                   defaults={'value': getattr(settings,
-                                                                             "OS_VERSION_VMXENAPI", "jessie")})
+                                                                             "OS_VERSION", "jessie")})
     secrets_prealocation_vm(vm)
 
     # PHPLibs

--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -153,7 +153,6 @@ STRONGHOLD_PUBLIC_NAMED_URLS = ('raven_login', 'raven_return')
 #CELERY_ACCEPT_CONTENT = ['json'] # TODO
 
 OS_VERSION = "jessie"
-OS_VERSION_VMXENAPI = "jessie"
 OS_DUE_UPGRADE = []
 
 NEXT_OS = 'stretch'

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -71,7 +71,7 @@ EMAIL_TIMEOUT = 60
 
 IP_REG_API_END_POINT = IP_REG_API_END_POINT + ['dev']
 
-OS_VERSION_VMXENAPI = "stretch"
+OS_VERSION = "stretch"
 OS_DUE_UPGRADE = ["jessie"]
 
 from mws.logging_configuration import *


### PR DESCRIPTION
OS_VERSION was unused and OS_VERSION_VMXENAPI was the setting that
set the OS version the panel would create VMs with. As the name
seems to be a vestige of an era where we thoughth we'd have differing
APIs for stretch and jessie, I've switched to using OS_VERSION and
deleted OS_VERSION_VMXENAPI