### PR TITLE
Backups every day

### DIFF
--- a/mws/mws/production_settings.py
+++ b/mws/mws/production_settings.py
@@ -60,7 +60,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'check_backups': {
         'task': 'sitesmanagement.cronjobs.check_backups',
-        'schedule': crontab(hour=12, minute=0'),
+        'schedule': crontab(hour=12, minute=0),
         'args': ()
     },
     'delete_cancelled': {

--- a/mws/mws/production_settings.py
+++ b/mws/mws/production_settings.py
@@ -60,7 +60,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'check_backups': {
         'task': 'sitesmanagement.cronjobs.check_backups',
-        'schedule': crontab(hour=12, minute=0, day_of_week='tue,wed,thu,fri,sat'),
+        'schedule': crontab(hour=12, minute=0'),
         'args': ()
     },
     'delete_cancelled': {


### PR DESCRIPTION
This PR removes  day restrictions on checking for backup success, meaning we will check every day. Handy, as we're taking backups every day now.