### PR TITLE
add conditions to show the button when upgrading

### DIFF
--- a/mws/templates/mws/show.html
+++ b/mws/templates/mws/show.html
@@ -109,11 +109,41 @@
                 </div>
             </div>
 
-            {% if site.production_service.due_update or site.production_service.active and site.test_service.active %}
-                {% if site.test_service and site.test_service.status != 'installing' and site.test_service.status != 'postinstall'  %}
-                    <div class="campl-column4">
-                        <div class="campl-content-container campl-side-padding">
-                            <a href="{% url 'sitesmanagement.views.clone_vm_view' site_id=site.id %}">
+            {% with prod_and_test_active=site.production_service.active and site.test_service.active %}
+                {% if site.production_service.due_update or prod_and_test_active %}
+                    {% if site.test_service and site.test_service.status != 'installing' and site.test_service.status != 'postinstall'  %}
+                        <div class="campl-column4">
+                            <div class="campl-content-container campl-side-padding">
+                                <a href="{% url 'sitesmanagement.views.clone_vm_view' site_id=site.id %}">
+                                    <article class="node node-external-link view-mode-focus_on clearfix
+                                                    campl-horizontal-teaser campl-teaser campl-focus-teaser">
+                                        <div class="campl-focus-teaser-img">
+                                            <div class="campl-content-container campl-horizontal-teaser-img">
+                                                <div class="field field-name-field-external-url-image field-type-image
+                                                            field-label-hidden">
+                                                    <div class="field-items">
+                                                        <div class="field-item even">
+                                                            <img class="campl-scale-with-grid"
+                                                                 src="{% static "icons/cloud-1.png" %}"
+                                                                 height="128" style="margin: 10px;" alt="">
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="campl-focus-teaser-txt">
+                                            <div class="campl-content-container campl-horizontal-teaser-txt">
+                                                <h3 class="campl-teaser-title">Test OS Upgrade</h3>
+                                                <span class="ir campl-focus-link"></span>
+                                            </div>
+                                        </div>
+                                    </article>
+                                </a>
+                            </div>
+                        </div>
+                    {% else %}
+                        <div class="campl-column4">
+                            <div class="campl-content-container campl-side-padding">
                                 <article class="node node-external-link view-mode-focus_on clearfix
                                                 campl-horizontal-teaser campl-teaser campl-focus-teaser">
                                     <div class="campl-focus-teaser-img">
@@ -132,44 +162,16 @@
                                     </div>
                                     <div class="campl-focus-teaser-txt">
                                         <div class="campl-content-container campl-horizontal-teaser-txt">
-                                            <h3 class="campl-teaser-title">Test OS Upgrade</h3>
+                                            <h3 class="campl-teaser-title" style="color: orangered">Test OS Upgrade (disabled while the test servers is being configured)</h3>
                                             <span class="ir campl-focus-link"></span>
                                         </div>
                                     </div>
                                 </article>
-                            </a>
+                            </div>
                         </div>
-                    </div>
-                {% else %}
-                    <div class="campl-column4">
-                        <div class="campl-content-container campl-side-padding">
-                            <article class="node node-external-link view-mode-focus_on clearfix
-                                            campl-horizontal-teaser campl-teaser campl-focus-teaser">
-                                <div class="campl-focus-teaser-img">
-                                    <div class="campl-content-container campl-horizontal-teaser-img">
-                                        <div class="field field-name-field-external-url-image field-type-image
-                                                    field-label-hidden">
-                                            <div class="field-items">
-                                                <div class="field-item even">
-                                                    <img class="campl-scale-with-grid"
-                                                         src="{% static "icons/cloud-1.png" %}"
-                                                         height="128" style="margin: 10px;" alt="">
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="campl-focus-teaser-txt">
-                                    <div class="campl-content-container campl-horizontal-teaser-txt">
-                                        <h3 class="campl-teaser-title" style="color: orangered">Test OS Upgrade (disabled while the test servers is being configured)</h3>
-                                        <span class="ir campl-focus-link"></span>
-                                    </div>
-                                </div>
-                            </article>
-                        </div>
-                    </div>
+                    {% endif %}
                 {% endif %}
-            {% endif %}
+            {% endwith %}
         {% endif %}
 
         {% if site.test_service and site.test_service.active and not site.test_service.is_busy %}

--- a/mws/templates/mws/show.html
+++ b/mws/templates/mws/show.html
@@ -109,7 +109,7 @@
                 </div>
             </div>
 
-            {% if site.production_service.due_update %}
+            {% if site.production_service.due_update or site.production_service.active and site.test_service.active %}
                 {% if site.test_service and site.test_service.status != 'installing' and site.test_service.status != 'postinstall'  %}
                     <div class="campl-column4">
                         <div class="campl-content-container campl-side-padding">


### PR DESCRIPTION
This PR makes the panel show the Test OS upgrade button whenever there are both test and production services active, ie. when in the middle of an OS upgrade.