### PR TITLE
move upgrade check from template to model

### DIFF
--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -200,6 +200,10 @@ class Site(models.Model):
         return Service.objects.filter(type='test', site=self).first()
 
     @property
+    def in_testing(self):
+        return self.production_service.active and self.test_service.active
+
+    @property
     @deprecated
     def primary_vm(self):
         return self.vms.filter(service__type='production').first()

--- a/mws/templates/mws/show.html
+++ b/mws/templates/mws/show.html
@@ -109,41 +109,11 @@
                 </div>
             </div>
 
-            {% with prod_and_test_active=site.production_service.active and site.test_service.active %}
-                {% if site.production_service.due_update or prod_and_test_active %}
-                    {% if site.test_service and site.test_service.status != 'installing' and site.test_service.status != 'postinstall'  %}
-                        <div class="campl-column4">
-                            <div class="campl-content-container campl-side-padding">
-                                <a href="{% url 'sitesmanagement.views.clone_vm_view' site_id=site.id %}">
-                                    <article class="node node-external-link view-mode-focus_on clearfix
-                                                    campl-horizontal-teaser campl-teaser campl-focus-teaser">
-                                        <div class="campl-focus-teaser-img">
-                                            <div class="campl-content-container campl-horizontal-teaser-img">
-                                                <div class="field field-name-field-external-url-image field-type-image
-                                                            field-label-hidden">
-                                                    <div class="field-items">
-                                                        <div class="field-item even">
-                                                            <img class="campl-scale-with-grid"
-                                                                 src="{% static "icons/cloud-1.png" %}"
-                                                                 height="128" style="margin: 10px;" alt="">
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="campl-focus-teaser-txt">
-                                            <div class="campl-content-container campl-horizontal-teaser-txt">
-                                                <h3 class="campl-teaser-title">Test OS Upgrade</h3>
-                                                <span class="ir campl-focus-link"></span>
-                                            </div>
-                                        </div>
-                                    </article>
-                                </a>
-                            </div>
-                        </div>
-                    {% else %}
-                        <div class="campl-column4">
-                            <div class="campl-content-container campl-side-padding">
+            {% if site.production_service.due_update or site.in_testing %}
+                {% if site.test_service and site.test_service.status != 'installing' and site.test_service.status != 'postinstall'  %}
+                    <div class="campl-column4">
+                        <div class="campl-content-container campl-side-padding">
+                            <a href="{% url 'sitesmanagement.views.clone_vm_view' site_id=site.id %}">
                                 <article class="node node-external-link view-mode-focus_on clearfix
                                                 campl-horizontal-teaser campl-teaser campl-focus-teaser">
                                     <div class="campl-focus-teaser-img">
@@ -162,16 +132,44 @@
                                     </div>
                                     <div class="campl-focus-teaser-txt">
                                         <div class="campl-content-container campl-horizontal-teaser-txt">
-                                            <h3 class="campl-teaser-title" style="color: orangered">Test OS Upgrade (disabled while the test servers is being configured)</h3>
+                                            <h3 class="campl-teaser-title">Test OS Upgrade</h3>
                                             <span class="ir campl-focus-link"></span>
                                         </div>
                                     </div>
                                 </article>
-                            </div>
+                            </a>
                         </div>
-                    {% endif %}
+                    </div>
+                {% else %}
+                    <div class="campl-column4">
+                        <div class="campl-content-container campl-side-padding">
+                            <article class="node node-external-link view-mode-focus_on clearfix
+                                            campl-horizontal-teaser campl-teaser campl-focus-teaser">
+                                <div class="campl-focus-teaser-img">
+                                    <div class="campl-content-container campl-horizontal-teaser-img">
+                                        <div class="field field-name-field-external-url-image field-type-image
+                                                    field-label-hidden">
+                                            <div class="field-items">
+                                                <div class="field-item even">
+                                                    <img class="campl-scale-with-grid"
+                                                         src="{% static "icons/cloud-1.png" %}"
+                                                         height="128" style="margin: 10px;" alt="">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="campl-focus-teaser-txt">
+                                    <div class="campl-content-container campl-horizontal-teaser-txt">
+                                        <h3 class="campl-teaser-title" style="color: orangered">Test OS Upgrade (disabled while the test servers is being configured)</h3>
+                                        <span class="ir campl-focus-link"></span>
+                                    </div>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
                 {% endif %}
-            {% endwith %}
+            {% endif %}
         {% endif %}
 
         {% if site.test_service and site.test_service.active and not site.test_service.is_busy %}


### PR DESCRIPTION
It looks like not only does Django not support parentheses in {% if %} blocks, but {% with %} blocks cannot have a compound expression either. This change adds a model property function that we can use in the template and modifies the template to make use of it.
Fixes #165 