### PR TITLE
create test service identical to production service

### DIFF
--- a/mws/apimws/xen.py
+++ b/mws/apimws/xen.py
@@ -283,6 +283,12 @@ def clone_vm_api_call(site):
         "secret": str(vm.token),
     }
 
+    parameters["features"] = {
+        "cpu": service.site.type.numcpu,
+        "ram": service.site.type.sizeram*1024,
+        "disk": service.site.type.sizedisk,
+    }
+
     service.status = 'installing'
     service.save()
 


### PR DESCRIPTION
test services used to be created with default values  for the VM parameters, but
this is not always correct, so use the appropriate values from the
site's ServerType