### PR TITLE
Only allow a set number of test servers

### DIFF
--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -154,7 +154,7 @@ STRONGHOLD_PUBLIC_NAMED_URLS = ('raven_login', 'raven_return')
 
 OS_VERSION = "stretch"
 OS_DUE_UPGRADE = []
-
+MAX_PENDING_UPGRADES = 20
 NEXT_OS = 'stretch'
 
 FINANCE_EMAIL = 'fh103@cam.ac.uk'

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -66,7 +66,7 @@ def clone_vm_view(request, site_id):
 
     can_upgrade = False
     if settings.MAX_PENDING_UPGRADES:
-        pending_upgrades = len([x for x in Service.objects.filter(type='test') if x.active])
+        pending_upgrades = len([x for x in Service.objects.filter(type='test').prefetch_related('virtual_machines') if x.active])
         if pending_upgrades < settings.MAX_PENDING_UPGRADES:
             can_upgrade = True
 

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -64,6 +64,12 @@ def clone_vm_view(request, site_id):
     if site is None:
         return HttpResponseForbidden()
 
+    can_upgrade = False
+    if settings.MAX_PENDING_UPGRADES:
+        pending_upgrades = len([x for x in Service.objects.filter(type='test') if x.active])
+        if pending_upgrades < settings.MAX_PENDING_UPGRADES:
+            can_upgrade = True
+
     breadcrumbs = {
         0: dict(name='Managed Web Service server: ' + str(site.name), url=site.get_absolute_url()),
         1: dict(name='Production and test servers management', url=reverse(clone_vm_view, kwargs={'site_id': site.id}))
@@ -82,6 +88,7 @@ def clone_vm_view(request, site_id):
     return render(request, 'mws/clone_vm.html', {
         'breadcrumbs': breadcrumbs,
         'site': site,
+        'can_upgrade': can_upgrade,
     })
 
 

--- a/mws/templates/mws/clone_vm.html
+++ b/mws/templates/mws/clone_vm.html
@@ -6,16 +6,20 @@
         <div class="campl-content-container">
             <h1 id="page-title">Production and test server management</h1>
             {% if site.production_service and site.production_service.virtual_machines.count > 0 and site.test_service and site.test_service.virtual_machines.count == 0 %}
-            <form action={% url 'sitesmanagement.views.clone_vm_view' site_id=site.id %} method="post">{% csrf_token %}
-                <fieldset>
-                        <div>
-                            <h3>Test the OS upgrade of the production server by creating a test server</h3>
-                            <p>
-                                <input type="submit" value="Clone Production server as Test server" class="campl-btn campl-primary-cta">
-                            </p>
-                        </div>
-                </fieldset>
-            </form>
+            {% if can_upgrade %}
+                <form action={% url 'sitesmanagement.views.clone_vm_view' site_id=site.id %} method="post">{% csrf_token %}
+                    <fieldset>
+                            <div>
+                                <h3>Test the OS upgrade of the production server by creating a test server</h3>
+                                <p>
+                                    <input type="submit" value="Clone Production server as Test server" class="campl-btn campl-primary-cta">
+                                </p>
+                            </div>
+                    </fieldset>
+                </form>
+            {% else %}
+                <h3>We cannot create a test server right now, please try again later</h3>
+            {% endif %}
             {% endif %}
             {% if site.test_service and site.test_service.virtual_machines.count != 0 %}
                 <form action={% url 'sitesmanagement.views.switch_services' site_id=site.id %} method="post">{% csrf_token %}


### PR DESCRIPTION
This PR blocks the creation of new test VMs if there are more than a configurable amount (20 was chosen as a starting value) of them already present.