### PR TITLE
remove fields

### DIFF
--- a/mws/sitesmanagement/views/sites.py
+++ b/mws/sitesmanagement/views/sites.py
@@ -219,7 +219,6 @@ class SiteEdit(SitePriviledgeAndBusyCheck, UpdateView):
 class SiteEditEmail(SitePriviledgeCheck, UpdateView):
     """View(Controller) to edit the email associated to a site"""
     form_class = SiteEmailForm
-    fields = '__all__'
 
     def render_to_response(self, context, **response_kwargs):
         return redirect(self.object)


### PR DESCRIPTION
On trying to change site admin email, Django would throw ImproperlyConfigured saying:
```Specifying` both 'fields' and 'form_class' is not permitted.```
This removes fields as it's already specified in the form class itself.