### PR TITLE
use live IPReg API endpoint instead of dev one

### DIFF
--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -69,6 +69,6 @@ VM_API = "apimws.xen"
 
 EMAIL_TIMEOUT = 60
 
-IP_REG_API_END_POINT = IP_REG_API_END_POINT + ['dev']
+IP_REG_API_END_POINT = IP_REG_API_END_POINT + ['live']
 
 from mws.logging_configuration import *


### PR DESCRIPTION
The dev endpoint does not do anything but swallows requests. We use
hostnames that are in the live system anyway and enabling this makes
testing hostname additions and TLS on test possible.

We can disable this later if we are worried it might hurt us.