### PR TITLE
Move media root and static root

### DIFF
--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -2,6 +2,7 @@ import os
 from django.conf import global_settings
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
@@ -85,11 +86,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static_dep')
+STATIC_ROOT = os.path.join(ROOT_DIR, 'static')
 STATIC_URL = '/static/'
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = os.path.join(ROOT_DIR, 'media')
 
 TEMPLATES = [
     {

--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -2,7 +2,7 @@ import os
 from django.conf import global_settings
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/


### PR DESCRIPTION
This PR makes Django use media and static directories at the level of the main checkout directory, eg. /var/www, so that we don't destroy these directories when we remove the checkout during a forced update.