### PR TITLE
Clone fix

### DIFF
--- a/mws/apimws/views.py
+++ b/mws/apimws/views.py
@@ -103,15 +103,15 @@ def confirm_email(request, ec_id, token):
 
 @shared_task(base=AnsibleTaskWithFailure, default_retry_delay=120, max_retries=2)
 def post_installOS(service):
+    if service.type == 'test':
+        subprocess.check_output(["userv", "mws-admin", "mws_clone",
+                                 service.site.production_service.virtual_machines.first().name,
+                                 service.site.test_service.virtual_machines.first().name])
     try:
         launch_ansible_async(service, ignore_host_key=True)
     except:
         # In case the previous task fail because we didn't leave enough time for the machine to reboot
         launch_ansible_async(service, ignore_host_key=True)
-    if service.type == 'test':
-        subprocess.check_output(["userv", "mws-admin", "mws_clone",
-                                 service.site.production_service.virtual_machines.first().name,
-                                 service.site.test_service.virtual_machines.first().name])
     if service.site.preallocated:
         service.site.disable()
 

--- a/mws/apimws/views.py
+++ b/mws/apimws/views.py
@@ -102,11 +102,11 @@ def confirm_email(request, ec_id, token):
 
 
 @shared_task(base=AnsibleTaskWithFailure, default_retry_delay=120, max_retries=2)
-def post_installOS(service):
+def post_installOS(service, initial=True):
     if service.type == 'test':
         subprocess.check_output(["userv", "mws-admin", "mws_clone",
                                  service.site.production_service.virtual_machines.first().name,
-                                 service.site.test_service.virtual_machines.first().name])
+                                 service.site.test_service.virtual_machines.first().name, initial])
     try:
         launch_ansible_async(service, ignore_host_key=True)
     except:

--- a/mws/apimws/views.py
+++ b/mws/apimws/views.py
@@ -106,7 +106,7 @@ def post_installOS(service, initial=True):
     if service.type == 'test':
         subprocess.check_output(["userv", "mws-admin", "mws_clone",
                                  service.site.production_service.virtual_machines.first().name,
-                                 service.site.test_service.virtual_machines.first().name, initial])
+                                 service.site.test_service.virtual_machines.first().name, str(initial)])
     try:
         launch_ansible_async(service, ignore_host_key=True)
     except:

--- a/mws/apimws/views.py
+++ b/mws/apimws/views.py
@@ -104,9 +104,12 @@ def confirm_email(request, ec_id, token):
 @shared_task(base=AnsibleTaskWithFailure, default_retry_delay=120, max_retries=2)
 def post_installOS(service, initial=True):
     if service.type == 'test':
-        subprocess.check_output(["userv", "mws-admin", "mws_clone",
-                                 service.site.production_service.virtual_machines.first().name,
-                                 service.site.test_service.virtual_machines.first().name, str(initial)])
+        command = ["userv", "mws-admin", "mws_clone",
+                   service.site.production_service.virtual_machines.first().name,
+                   service.site.test_service.virtual_machines.first().name]
+        if initial:
+            command.append('--initial')
+        subprocess.check_output(command)
     try:
         launch_ansible_async(service, ignore_host_key=True)
     except:

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -409,6 +409,6 @@ def resync(request, site_id):
         return redirect(site)
 
     if request.method == 'POST':
-        post_installOS.delay(site.test_service)
+        post_installOS.delay(site.test_service, initial=False)
     messages.info(request, 'The filesystem started to synchronise')
     return redirect(site)


### PR DESCRIPTION
This PR adds ```post_installOS``` support for cloning to a test service that has not had Ansible run yet.