### PR TITLE
use 2.x series version of redis-py

### DIFF
--- a/mws/requirements.txt
+++ b/mws/requirements.txt
@@ -13,6 +13,6 @@ mock>=1.0.1
 psycopg2-binary
 pycrypto>=2.6.1
 pyyaml
-redis
+redis~=2.10
 requests
 python-dateutil


### PR DESCRIPTION
The 3.x series currently break Celery, so fix to 2.x now. Thanks to Sam and Wajdi.