### PR TITLE
pass hostname status off to Ansible

### DIFF
--- a/mws/apimws/management/commands/ansible_inventory.py
+++ b/mws/apimws/management/commands/ansible_inventory.py
@@ -122,8 +122,8 @@ class Command(BaseCommand):
             vhv['id'] = vh.id
             vhv['name'] = vh.name
             # List of domain names associated to the vhost (only those already accepted or external [non cam.ac.uk])
-            vhv['domains'] = [dom.name for dom in
-                              vh.domain_names.filter(Q(status='accepted') | Q(status='external') | Q(status='special'))]
+            vhv['domains'] = {dom.name: dom.status for dom in
+                              vh.domain_names.filter(Q(status='accepted') | Q(status='external') | Q(status='special'))}
             # The main domain where all the domain names associated will redirect to
             if vh.main_domain:
                 vhv['main_domain'] = vh.main_domain.name


### PR DESCRIPTION
**POTENTIALLY BREAKING CHANGE. ONLY TO BE MERGED IN COORDINATION WITH uisautomation/mws-ansible/pull/221**
Let's Encrypt will only issue certificates for hostnames it can
resolve, so we need to tell Ansible about the status of each
configured hostname.