### PR TITLE
Validate domains

### DIFF
--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -166,3 +166,28 @@ IP_REG_API_END_POINT = ['userv', 'mws-admin', 'mws_ipreg']
 
 # Maximum length of time which a domain can remain unapproved.
 MWS_DOMAIN_NAME_GRACE_DAYS = 30
+
+# nameservers to validate hostnames against, with tighter scopes first
+# SCOPEs actually correspond to the items in DomainName.STATUS_CHOICES
+MWS_RESOLVERS = [
+    {
+        'SCOPE': 'private',
+        'SERVERS': [
+            '131.111.12.20',
+            '131.111.8.42',
+        ],
+        'RESOLVER': dns.resolver.Resolver()
+    },
+    {
+        'SCOPE': 'global',
+        'SERVERS': [
+            '8.8.8.8',
+            '8.8.4.4',
+        ],
+        'RESOLVER': dns.resolver.Resolver()
+    },
+]
+
+# there is no other way to add nameservers to a Resolver()
+for resolver in MWS_RESOLVERS:
+    resolver['RESOLVER'].nameservers = resolver['SERVERS']

--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -168,22 +168,22 @@ IP_REG_API_END_POINT = ['userv', 'mws-admin', 'mws_ipreg']
 # Maximum length of time which a domain can remain unapproved.
 MWS_DOMAIN_NAME_GRACE_DAYS = 30
 
-# nameservers to validate hostnames against, with tighter scopes first
+# nameservers to validate hostnames against, with tighter scopes last
 # SCOPEs actually correspond to the items in DomainName.STATUS_CHOICES
 MWS_RESOLVERS = [
-    {
-        'SCOPE': 'private',
-        'SERVERS': [
-            '131.111.12.20',
-            '131.111.8.42',
-        ],
-        'RESOLVER': dns.resolver.Resolver()
-    },
     {
         'SCOPE': 'global',
         'SERVERS': [
             '8.8.8.8',
             '8.8.4.4',
+        ],
+        'RESOLVER': dns.resolver.Resolver()
+    },
+    {
+        'SCOPE': 'private',
+        'SERVERS': [
+            '131.111.12.20',
+            '131.111.8.42',
         ],
         'RESOLVER': dns.resolver.Resolver()
     },

--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -1,5 +1,6 @@
 import os
 from django.conf import global_settings
+import dns.resolver
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))

--- a/mws/requirements.txt
+++ b/mws/requirements.txt
@@ -16,3 +16,4 @@ pyyaml
 redis~=2.10
 requests
 python-dateutil
+dnspython

--- a/mws/sitesmanagement/cronjobs.py
+++ b/mws/sitesmanagement/cronjobs.py
@@ -309,25 +309,3 @@ def reject_or_accepted_old_domain_names_requests():
                                    "%s days.") % (grace_days,))
         else:
             domain_name.accept_it()
-
-
-@shared_task
-def validate_domains():
-    '''
-    Iterate over DomainName objects that we manage and set them to:
-     - private if they are only available to the Cambridge nameservers
-     - global if they are visible to (currently) Google's nameservers
-     - deleted if they are visible to none of the above.
-
-    Names that stay 'deleted' for grace_days are removed from the database.
-    An Ansible run is triggered for services that had DomainName status changes.
-    '''
-    # TODO: make the Ansible run only update Let's Encrypt, so it runs quicker.
-    grace_days = settings.MWS_DOMAIN_NAME_GRACE_DAYS
-    active_states = ['accepted', 'private', 'global']
-
-    for site in Site.objects.filter(deleted=False, preallocated=False, disabled=False):
-        for service in site.services.filter(type='production'):
-            for vhost in service.vhosts.all():
-                for domainname in vhost.domain_names.filter(status__in=active_states):                                                                               
-                    pass

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -697,7 +697,7 @@ class DomainName(models.Model):
         import dns.name
         import dns.rdatatype
 
-        if all(resolver, nameservers):
+        if resolver and nameservers:
             raise ValueError('resolver and nameservers are mutually exclusive')
 
         r = resolver if resolver and callable(resolver) else dns.resolver.Resolver()

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -700,7 +700,7 @@ class DomainName(models.Model):
         if resolver and nameservers:
             raise ValueError('resolver and nameservers are mutually exclusive')
 
-        r = resolver if resolver and callable(resolver) else dns.resolver.Resolver()
+        r = resolver if resolver else dns.resolver.Resolver()
         r.nameservers = nameservers if nameservers else r.nameservers
         dnsname = dns.name.from_text(self.name)
         ip4 = self.vhost.service.network_configuration.IPv4
@@ -727,7 +727,7 @@ class DomainName(models.Model):
                 if self.resolve(resolver=resolver['RESOLVER']):
                     results.append(resolver['SCOPE'])
             if results:
-                status = results[-1] if status not in ['external', 'special'] else status
+                status = results[0] if status not in ['external', 'special'] else status
             else:
                 status = 'deleted'
             if update and self.status != status:

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -725,6 +725,7 @@ class DomainName(models.Model):
         for resolver in settings.MWS_RESOLVERS:
             if self.resolve(resolver=resolver['RESOLVER']):
                 status = resolver['SCOPE'] if status not in ['external', 'special'] else status
+                break
             else:
                 status = 'deleted'
         if update and self.status != status:

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -720,7 +720,7 @@ class DomainName(models.Model):
         # nameservers to validate hostnames against, with tighter scopes last
         # SCOPEs should be named after the items in DomainName.STATUS_CHOICES
         status = self.status
-        for resolver in MWS_RESOLVERS:
+        for resolver in settings.MWS_RESOLVERS:
             if resolve(resolver=resolver['RESOLVER']):
                 status = resolver['SCOPE'] if status not in ['external', 'special'] else status
             else:

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -701,7 +701,7 @@ class DomainName(models.Model):
             raise ValueError('resolver and nameservers are mutually exclusive')
 
         r = resolver if resolver and callable(resolver) else dns.resolver.Resolver()
-        r.nameservers = nameservers if nameservers
+        r.nameservers = nameservers if nameservers else r.nameservers
         dnsname = dns.name.from_text(self.name)
         ip4 = self.vhost.service.network_configuration.IPv4
         ip6 = self.vhost.service.network_configuration.IPv6

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -714,7 +714,7 @@ class DomainName(models.Model):
                     if status not in ['external', 'special']:
                         status = resolver['SCOPE']
             except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.NoNameservers):
-                status = 'deleted'
+                status = 'deleted' if status == 'deleted' else status
         if update and self.status != status:
             self.status = status
             self.save()

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -720,6 +720,8 @@ class DomainName(models.Model):
         # nameservers to validate hostnames against, with tighter scopes last
         # SCOPEs should be named after the items in DomainName.STATUS_CHOICES
         status = self.status
+        if status in ['requested', 'denied']:
+            return status
         for resolver in settings.MWS_RESOLVERS:
             if self.resolve(resolver=resolver['RESOLVER']):
                 status = resolver['SCOPE'] if status not in ['external', 'special'] else status

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -721,7 +721,7 @@ class DomainName(models.Model):
         # SCOPEs should be named after the items in DomainName.STATUS_CHOICES
         status = self.status
         for resolver in settings.MWS_RESOLVERS:
-            if resolve(resolver=resolver['RESOLVER']):
+            if self.resolve(resolver=resolver['RESOLVER']):
                 status = resolver['SCOPE'] if status not in ['external', 'special'] else status
             else:
                 status = 'deleted'

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -701,7 +701,7 @@ class DomainName(models.Model):
             try:
                 r = resolver['RESOLVER']
                 if any([
-                    netname in [CNAME.to_text()
+                    netname in [CNAME.to_text()[:-1]
                         for CNAME in r.query(hostname, 'CNAME').rrset.items
                         if CNAME.rdtype == dns.rdatatype.CNAME],
                     ip4 in [A.to_text()

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -686,7 +686,7 @@ class DomainName(models.Model):
         self.save()
         # TODO send email as special
 
-    def resolve(self, resolver=None, nameservers=None):
+    def _resolve(self, resolver=None, nameservers=None):
         '''
         Attempt to resolve DomainName, using either specified or default nameservers
         or a custom resolver callable.
@@ -724,7 +724,7 @@ class DomainName(models.Model):
         results = []
         if status not in ['requested', 'denied']:
             for resolver in settings.MWS_RESOLVERS:
-                if self.resolve(resolver=resolver['RESOLVER']):
+                if self._resolve(resolver=resolver['RESOLVER']):
                     results.append(resolver['SCOPE'])
             if results:
                 status = results[0] if status not in ['external', 'special'] else status


### PR DESCRIPTION
This PR adds a validator method that checks the validity of a recorded `DomainName` name. A name is considered valid if resolves to either an A or AAAA record with the respective address of the MWS service. Depending on the status of the DomainName, validation outcomes are as follows:
 - `requested` names are ignored as they are handled by the `accept_it()` method
 - `denied` names are ignored, it being a final state
 - `external` and `special` names are checked and are set to `deleted` if they are invalid
 - `accepted`, `private` and `global` names' statuses are set according to their validity returned by the resolvers configured in `MWS_RESOLVERS`. If all resolvers deny the existence of the name, it will be set to `deleted`
 - `deleted` names are given a grace period of `MWS_DOMAIN_NAME_GRACE_DAYS`, after which they will be deleted from the database by a periodic task yet to be pushed.
