### PR TITLE
Mws proxies

### DIFF
--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -192,3 +192,11 @@ MWS_RESOLVERS = [
 # there is no other way to add nameservers to a Resolver()
 for resolver in MWS_RESOLVERS:
     resolver['RESOLVER'].nameservers = resolver['SERVERS']
+
+# IP addresses of hosts we want to allow to proxy for the MWS
+MWS_ALLOWED_PROXIES = [
+    # primary.admin.cam.ac.uk
+    131.111.150.25,
+    # doitpoms.admin.cam.ac.uk
+    131.111.150.168,
+]

--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -195,8 +195,6 @@ for resolver in MWS_RESOLVERS:
 
 # IP addresses of hosts we want to allow to proxy for the MWS
 MWS_ALLOWED_PROXIES = [
-    # primary.admin.cam.ac.uk
-    131.111.150.25,
     # doitpoms.admin.cam.ac.uk
     131.111.150.168,
 ]

--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -196,5 +196,5 @@ for resolver in MWS_RESOLVERS:
 # IP addresses of hosts we want to allow to proxy for the MWS
 MWS_ALLOWED_PROXIES = [
     # doitpoms.admin.cam.ac.uk
-    131.111.150.168,
+    '131.111.150.168',
 ]

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -702,17 +702,20 @@ class DomainName(models.Model):
 
         r = resolver if resolver else dns.resolver.Resolver()
         r.nameservers = nameservers if nameservers else r.nameservers
+        proxies = getattr(settings, 'MWS_ALLOWED_PROXIES', [])
         dnsname = dns.name.from_text(self.name)
         ip4 = self.vhost.service.network_configuration.IPv4
         ip6 = self.vhost.service.network_configuration.IPv6
 
         try:
             answer = r.query(dnsname, 'AAAA')
-            return ip6 in [AAAA.to_text() for AAAA in answer.rrset.items if AAAA.rdtype == dns.rdatatype.AAAA]
+            return ip6 in [AAAA.to_text() for AAAA in answer.rrset.items if AAAA.rdtype == dns.rdatatype.AAAA] or
+                   ip6 in proxies
         except:
             try:
                 answer = r.query(dnsname, 'A')
-                return ip4 in [A.to_text() for A in answer.rrset.items if A.rdtype == dns.rdatatype.A]
+                return ip4 in [A.to_text() for A in answer.rrset.items if A.rdtype == dns.rdatatype.A] or
+                       ip4 in proxies
             except:
                 return False
 


### PR DESCRIPTION
The doitpoms site is behind the traffic manager because it in a sad state. This makes its hostname not resolve to a MWS address and domain validation to fail. To cope with this and future issues like it, add an MWS_ALLOWED_PROXIES setting to hold addresses that indirectly map (proxy) to the MWS and some code to include them in the validation.