### PR TITLE
Cert hostnames

### DIFF
--- a/mws/apimws/management/commands/ansible_inventory.py
+++ b/mws/apimws/management/commands/ansible_inventory.py
@@ -124,11 +124,13 @@ class Command(BaseCommand):
             # List of all hostnames accepted at least once.
             vhv['domains'] = {dom.name: dom.status for dom in
                               vh.domain_names.exclude(status__in=['denied', 'requested'])}
-            # Dict of lists of hostnames that certain providers can support, keyed by provider
+            # Dict of lists of hostnames that certain certificate providers can support, keyed by provider
             vhv['cert_domains'] = {
+                # ACME (Let's Encrypt) can only certify hostnames it can resolve
                 'acme': [dom.name for dom in
                          vh.domain_names.filter(status__in=['global', 'external', 'special']).exclude(
                          name=vh.service.network_configuration.name)],
+                # QuoVadis will certify tentative and private hostnames as well
                 'qv': [dom.name for dom in
                        vh.domain_names.filter(status__in=['accepted', 'private', 'global', 'external', 'special'])],
             }

--- a/mws/apimws/management/commands/ansible_inventory.py
+++ b/mws/apimws/management/commands/ansible_inventory.py
@@ -121,9 +121,17 @@ class Command(BaseCommand):
             vhv = {}
             vhv['id'] = vh.id
             vhv['name'] = vh.name
-            # List of domain names associated to the vhost (only those already accepted or external [non cam.ac.uk])
+            # List of all hostnames accepted at least once.
             vhv['domains'] = {dom.name: dom.status for dom in
-                              vh.domain_names.filter(status__in=['accepted', 'private', 'global', 'external', 'special'])}
+                              vh.domain_names.exclude(status__in=['denied', 'requested'])}
+            # Dict of lists of hostnames that certain providers can support, keyed by provider
+            vhv['cert_domains'] = {
+                'acme': [dom.name for dom in
+                         vh.domain_names.filter(status__in=['global', 'external', 'special']).exclude(
+                         name=vh.service.network_configuration.name)],
+                'qv': [dom.name for dom in
+                       vh.domain_names.filter(status__in=['accepted', 'private', 'global', 'external', 'special'])],
+            }
             # The main domain where all the domain names associated will redirect to
             if vh.main_domain:
                 vhv['main_domain'] = vh.main_domain.name

--- a/mws/apimws/management/commands/ansible_inventory.py
+++ b/mws/apimws/management/commands/ansible_inventory.py
@@ -95,9 +95,9 @@ class Command(BaseCommand):
 
     def hostvars(self, vm):
         v = {}
-        v['ansible_ssh_host'] = (vm.network_configuration.name or
-                                 vm.network_configuration.IPv4 or
-                                 vm.network_configuration.IPv6)
+        v['ansible_host'] = (vm.network_configuration.name or
+                             vm.network_configuration.IPv4 or
+                             vm.network_configuration.IPv6)
         v['mws_name'] = vm.site.name
         v['mws_webmaster_email'] = vm.site.email
 

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -624,15 +624,15 @@ class Vhost(models.Model):
 
 
 class DomainName(models.Model):
-    STATUS_CHOICES = (
-        ('requested', 'Requested'),
-        ('accepted', 'Accepted'),
-        ('private', 'Private'),
-        ('global', 'Global'),
-        ('external', 'External'),
-        ('special', 'Special'),
-        ('denied', 'Denied'),
-        ('deleted', 'Deleted'),
+    STATUS_CHOICES = (              # The hostname:
+        ('requested', 'Requested'), #   has been requested through the panel
+        ('accepted', 'Accepted'),   #   has been accepted by the domain owner
+        ('private', 'Private'),     #   has validated as visible within the CUDN
+        ('global', 'Global'),       #   has validated as world-visible
+        ('external', 'External'),   #   is in a zone we don't control
+        ('special', 'Special'),     #   is under cam.ac.uk, but the MWS can't add/rescind it
+        ('denied', 'Denied'),       #   has not been accepted by the domain owner
+        ('deleted', 'Deleted'),     #   has failed validation and is scheduled to be deleted
     )
 
     name = models.CharField(max_length=250, unique=True, validators=[full_domain_validator])


### PR DESCRIPTION
This PR tries to make it easier to use hostnames from Ansible by adding a dict to the inventory that holds lists of eligible hostnames keyed by the certificate provider. It also changes `ansible_ssh_host` (now deprecated) to `ansible_host`.