### PR TITLE
Make metrics URL configurable

### DIFF
--- a/mws/mws/production_settings.py
+++ b/mws/mws/production_settings.py
@@ -106,4 +106,6 @@ EMAIL_TIMEOUT = 60
 
 IP_REG_API_END_POINT = IP_REG_API_END_POINT + ['live']
 
+METRICS_URL = 'https://sliderule.mws3.csx.cam.ac.uk/dashboard/script/mws3.js'
+
 from mws.logging_configuration import *

--- a/mws/mws/settings_developer.py
+++ b/mws/mws/settings_developer.py
@@ -55,3 +55,5 @@ VM_END_POINT_COMMAND = ["vmmanager"]
 CELERY_EAGER_PROPAGATES_EXCEPTIONS=True
 CELERY_ALWAYS_EAGER=True
 BROKER_BACKEND='memory'
+
+METRICS_URL = 'http://localhost:3000/dashboard/script/mws3.js'

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -81,4 +81,6 @@ EMAIL_TIMEOUT = 60
 
 IP_REG_API_END_POINT = IP_REG_API_END_POINT + ['live']
 
+METRICS_URL = 'https://test.dev.mws3.csx.cam.ac.uk:3000/dashboard/script/mws3.js'
+
 from mws.logging_configuration import *

--- a/mws/sitesmanagement/views/sites.py
+++ b/mws/sitesmanagement/views/sites.py
@@ -184,6 +184,7 @@ class SiteShow(SitePriviledgeCheck, DetailView):
             0: dict(name='Managed Web Service server: ' + str(self.object.name), url=self.object.get_absolute_url())
         }
         context['MAIN_DOMAIN'] = getattr(django_settings, 'MAIN_DOMAIN', False)
+        context['metrics_url'] = getattr(django_settings, 'METRICS_URL', False)
         context['stats_name'] = self.object.production_service.network_configuration.name.replace(".","_")
         try:
             context['main_website'] = Vhost.objects.get(name="default", service=self.object.production_service)

--- a/mws/templates/mws/show.html
+++ b/mws/templates/mws/show.html
@@ -203,7 +203,7 @@
                 </div>
             </div>
         {% endif %}
-
+        {% if metrics_url %}
             <div class="campl-column4">
                 <div class="campl-content-container campl-side-padding">
                     <a href="{{ metrics_url }}?name={{ stats_name }}">
@@ -229,7 +229,7 @@
                     </a>
                 </div>
             </div>
-
+        {% endif %}
             <div class="campl-column4">
                 <div class="campl-content-container campl-side-padding">
                     <a href="{% url 'billing_management' site_id=site.id %}">

--- a/mws/templates/mws/show.html
+++ b/mws/templates/mws/show.html
@@ -206,7 +206,7 @@
 
             <div class="campl-column4">
                 <div class="campl-content-container campl-side-padding">
-                    <a href="https://sliderule.mws3.csx.cam.ac.uk/dashboard/script/mws3.js?name={{ stats_name }}">
+                    <a href="{{ metrics_url }}?name={{ stats_name }}">
                         <article class="node node-external-link view-mode-focus_on clearfix campl-horizontal-teaser campl-teaser campl-focus-teaser">
                             <div class="campl-focus-teaser-img">
                                 <div class="campl-content-container campl-horizontal-teaser-img">


### PR DESCRIPTION
This is to enable testing of dashboard features (uisautomation/mws-ansible#228 and uisautomation/mws-ansible#237)and to prepare us for the moving of Grafana from boarstall.csx to mws3-live-panel1.srv.uis (uisautomation/mws-ansible#236).