### PR TITLE
move domains list into Vhost object

### DIFF
--- a/mws/apimws/management/commands/ansible_inventory.py
+++ b/mws/apimws/management/commands/ansible_inventory.py
@@ -122,17 +122,13 @@ class Command(BaseCommand):
             vhv['id'] = vh.id
             vhv['name'] = vh.name
             # List of all hostnames accepted at least once.
-            vhv['domains'] = {dom.name: dom.status for dom in
-                              vh.domain_names.exclude(status__in=['denied', 'requested'])}
+            vhv['domains'] = vh.domains()
             # Dict of lists of hostnames that certain certificate providers can support, keyed by provider
             vhv['cert_domains'] = {
                 # ACME (Let's Encrypt) can only certify hostnames it can resolve
-                'acme': [dom.name for dom in
-                         vh.domain_names.filter(status__in=['global', 'external', 'special']).exclude(
-                         name=vh.service.network_configuration.name)],
+                'acme': vh.domains(global_only=True)
                 # QuoVadis will certify tentative and private hostnames as well
-                'qv': [dom.name for dom in
-                       vh.domain_names.filter(status__in=['accepted', 'private', 'global', 'external', 'special'])],
+                'qv': vh.domains(global_only=False)
             }
             # The main domain where all the domain names associated will redirect to
             if vh.main_domain:

--- a/mws/apimws/management/commands/ansible_inventory.py
+++ b/mws/apimws/management/commands/ansible_inventory.py
@@ -126,9 +126,9 @@ class Command(BaseCommand):
             # Dict of lists of hostnames that certain certificate providers can support, keyed by provider
             vhv['cert_domains'] = {
                 # ACME (Let's Encrypt) can only certify hostnames it can resolve
-                'acme': vh.domains(global_only=True)
+                'acme': vh.domains(subset=vh.GLOBAL_NAMES)
                 # QuoVadis will certify tentative and private hostnames as well
-                'qv': vh.domains(global_only=False)
+                'qv': vh.domains(subset=vh.PRIVATE_AND_GLOBAL_NAMES)
             }
             # The main domain where all the domain names associated will redirect to
             if vh.main_domain:

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -593,7 +593,7 @@ class Vhost(models.Model):
 
     ALL_NAMES = ['denied', 'requested']
     GLOBAL_NAMES = ['global', 'external', 'special']
-    PRIVATE_AND_GLOBAL_NAMES = GLOBAL_NAMES.extend(['accepted', 'private'])
+    PRIVATE_AND_GLOBAL_NAMES = GLOBAL_NAMES + ['accepted', 'private']
 
     name = models.CharField(max_length=60, validators=[validate_slug])
     # main domain name for this vhost

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -636,11 +636,12 @@ class Vhost(models.Model):
             # all eligible names
             names = [dom.name for dom in vh.domain_names.exclude(status__in=ALL_NAMES)]
         elif subset is GLOBAL_NAMES:
-            # only names that are globally available
+            # only names that are globally available, except the service hostname
             names = [dom.name for dom in vh.domain_names.filter(status__in=GLOBAL_NAMES).exclude(
                      name=vh.service.network_configuration.name)]
         elif subset is PRIVATE_AND_GLOBAL_NAMES:
             # both private and global names
+            # TODO: remove service hostname from here as well
             names = [dom.name for dom in vh.domain_names.filter(status__in=PRIVATE_AND_GLOBAL_NAMES)]
         else:
             raise ValueError('Unknown subset type: %r' % (subset,))

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -590,6 +590,11 @@ class Vhost(models.Model):
     WEBAPP_CHOICES = (
         ('wordpress', 'Wordpress'),
     )
+
+    ALL_NAMES = ['denied', 'requested']
+    GLOBAL_NAMES = ['global', 'external', 'special']
+    PRIVATE_AND_GLOBAL_NAMES = GLOBAL_NAMES.extend(['accepted', 'private'])
+
     name = models.CharField(max_length=60, validators=[validate_slug])
     # main domain name for this vhost
     main_domain = models.ForeignKey('DomainName', related_name='+', null=True, blank=True, on_delete=models.SET_NULL)
@@ -623,20 +628,22 @@ class Vhost(models.Model):
         return self.name
 
 
-    def domains(self, global_only=None):
+    def domains(self, subset=ALL_NAMES):
         '''
         Return the list of hostnames for the vhost, optionally filtering it.
         '''
-        if global_only is None:
+        if subset is ALL_NAMES:
             # all eligible names
-            names = [dom.name for dom in vh.domain_names.exclude(status__in=['denied', 'requested'])]
-        elif global_only:
+            names = [dom.name for dom in vh.domain_names.exclude(status__in=ALL_NAMES)]
+        elif subset is GLOBAL_NAMES:
             # only names that are globally available
-            names = [dom.name for dom in vh.domain_names.filter(status__in=['global', 'external', 'special']).exclude(
+            names = [dom.name for dom in vh.domain_names.filter(status__in=GLOBAL_NAMES).exclude(
                      name=vh.service.network_configuration.name)]
-        else:
+        elif subset is PRIVATE_AND_GLOBAL_NAMES:
             # both private and global names
-            names = [dom.name for dom in vh.domain_names.filter(status__in=['accepted', 'private', 'global', 'external', 'special'])]
+            names = [dom.name for dom in vh.domain_names.filter(status__in=PRIVATE_AND_GLOBAL_NAMES)]
+        else:
+            raise ValueError('Unknown subset type: %r' % (subset,))
         return names
 
 

--- a/mws/sitesmanagement/models.py
+++ b/mws/sitesmanagement/models.py
@@ -623,6 +623,23 @@ class Vhost(models.Model):
         return self.name
 
 
+    def domains(self, global_only=None):
+        '''
+        Return the list of hostnames for the vhost, optionally filtering it.
+        '''
+        if global_only is None:
+            # all eligible names
+            names = [dom.name for dom in vh.domain_names.exclude(status__in=['denied', 'requested'])]
+        elif global_only:
+            # only names that are globally available
+            names = [dom.name for dom in vh.domain_names.filter(status__in=['global', 'external', 'special']).exclude(
+                     name=vh.service.network_configuration.name)]
+        else:
+            # both private and global names
+            names = [dom.name for dom in vh.domain_names.filter(status__in=['accepted', 'private', 'global', 'external', 'special'])]
+        return names
+
+
 class DomainName(models.Model):
     STATUS_CHOICES = (              # The hostname:
         ('requested', 'Requested'), #   has been requested through the panel


### PR DESCRIPTION
**This PR requires that uisautomation/mws-ansible#244 be merged at the same time, as these two contain mutually breaking changes.**

As we'll use the various lists of hostnames in templates, it makes sense to add generating them to the Vhost model. This also removes passing down hostname status in `vhv['domains']`