### PR TITLE
Fix ucamlookup Version

### DIFF
--- a/mws/requirements.txt
+++ b/mws/requirements.txt
@@ -4,7 +4,7 @@ django-celery
 django-debug-toolbar
 django-reversion
 django-stronghold>=0.2.6
-django-ucamlookup==1.9.*
+django-ucamlookup~=1.9.5
 django-ucamprojectlight>=1.1
 django-ucamwebauth>=1.2
 django>=1.11,<1.12

--- a/mws/requirements.txt
+++ b/mws/requirements.txt
@@ -4,7 +4,7 @@ django-celery
 django-debug-toolbar
 django-reversion
 django-stronghold>=0.2.6
-django-ucamlookup>=1.9.5
+django-ucamlookup==1.9.*
 django-ucamprojectlight>=1.1
 django-ucamwebauth>=1.2
 django>=1.11,<1.12


### PR DESCRIPTION
Fix `django-ucamlookup` at a version before 3 as it has a breaking change.

closes: #216 
