### PR TITLE
install from source

### DIFF
--- a/mws/requirements.txt
+++ b/mws/requirements.txt
@@ -10,7 +10,7 @@ django-ucamwebauth>=1.2
 django>=1.11,<1.12
 ecdsa
 mock>=1.0.1
-psycopg2-binary
+psycopg2
 pycrypto>=2.6.1
 pyyaml
 redis~=2.10


### PR DESCRIPTION
This makes pip install the non-binary package for psycopg2.
Fixes #218 