### PR TITLE
Test server nagger

### DIFF
--- a/mws/mws/common_settings.py
+++ b/mws/mws/common_settings.py
@@ -156,7 +156,7 @@ STRONGHOLD_PUBLIC_NAMED_URLS = ('raven_login', 'raven_return')
 
 OS_VERSION = "stretch"
 OS_DUE_UPGRADE = ["jessie"]
-MAX_PENDING_UPGRADES = 20
+MAX_PENDING_UPGRADES = 60
 NEXT_OS = 'stretch'
 
 FINANCE_EMAIL = 'finance@uis.cam.ac.uk'

--- a/mws/mws/production_settings.py
+++ b/mws/mws/production_settings.py
@@ -93,6 +93,11 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=1, minute=5),
         'args': ()
     },
+    'send_reminder_delete_upgraded': {
+        'task': 'sitesmanagement.cronjobs.send_reminder_delete_upgraded',
+        'schedule': crontab(hour=11, minute=0, day_of_week='1,3,5'),
+        'args': ()
+    },
 }
 
 MIDDLEWARE_CLASSES += (

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -68,6 +68,11 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=1, minute=5),
         'args': ()
     },
+    'send_reminder_delete_upgraded': {
+        'task': 'sitesmanagement.cronjobs.send_reminder_delete_upgraded',
+        'schedule': crontab(day_of_week='1,3,5'),
+        'args': ()
+    },
 }
 
 MIDDLEWARE_CLASSES += (

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -68,11 +68,6 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=1, minute=5),
         'args': ()
     },
-    'send_reminder_delete_upgraded': {
-        'task': 'sitesmanagement.cronjobs.send_reminder_delete_upgraded',
-        'schedule': crontab(hour=11, minute=0, day_of_week='1,3,5'),
-        'args': ()
-    },
 }
 
 MIDDLEWARE_CLASSES += (

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -70,7 +70,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'send_reminder_delete_upgraded': {
         'task': 'sitesmanagement.cronjobs.send_reminder_delete_upgraded',
-        'schedule': crontab(day_of_week='1,3,5'),
+        'schedule': crontab(hour=11, minute=0, day_of_week='1,3,5'),
         'args': ()
     },
 }

--- a/mws/sitesmanagement/cronjobs.py
+++ b/mws/sitesmanagement/cronjobs.py
@@ -384,7 +384,7 @@ def send_reminder_delete_upgraded():
     '''
     for site in Site.objects.all():
         if site.secondary_vm and site.secondary_vm.operating_system == 'jessie':
-            conf_url = reverse('sitesmanagement.views.service_settings', kwargs={'service_id': site.test_service.pk}))
+            conf_url = reverse('sitesmanagement.views.service_settings', kwargs={'service_id': site.test_service.pk})
             EmailMessage(
                 subject="MWS test server for %s" % (site.name),
                 body="We noticed that your site is now running on an upgraded server, but the "

--- a/mws/sitesmanagement/cronjobs.py
+++ b/mws/sitesmanagement/cronjobs.py
@@ -391,7 +391,7 @@ def send_reminder_delete_upgraded():
                      "old server has not been deleted yet. As the number of test servers the "
                      "MWS can support is limited, this may be blocking others from upgrading.\n"
                      "If you're happy with the new server, please delete the old one by "
-                     "visiting\n\nhttps://panel.mws3.csx.cam.ac.uk%s\n\n and clicking the "
+                     "visiting\n\nhttps://panel.mws3.csx.cam.ac.uk%s\n\nand clicking the "
                      "'Delete the test server' button.\n\nThanks,\nMWS Support\n" % (conf_url),
                 from_email="Managed Web Service Support <%s>"
                            % getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk'),


### PR DESCRIPTION
This PR adds a cronjob to remind users to delete test servers for sites that have switched to stretch and increases the number of test VMs in flight to 60.