### PR TITLE
Periodic queue check

### DIFF
--- a/mws/mws/production_settings.py
+++ b/mws/mws/production_settings.py
@@ -98,6 +98,11 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=11, minute=0, day_of_week='1,3,5'),
         'args': ()
     },
+    'dequeue_upgrades': {
+        'task': 'sitesmanagement.cronjobs.dequeue_upgrades',
+        'schedule': timedelta(minutes=30),
+        'args': ()
+    },
 }
 
 MIDDLEWARE_CLASSES += (

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -68,11 +68,6 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=1, minute=5),
         'args': ()
     },
-    'dequeue_upgrades': {
-        'task': 'sitesmanagement.cronjobs.dequeue_upgrades',
-        'schedule': timedelta(minutes=30),
-        'args': ()
-    },
 }
 
 MIDDLEWARE_CLASSES += (

--- a/mws/mws/settings_test.py
+++ b/mws/mws/settings_test.py
@@ -68,6 +68,11 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=1, minute=5),
         'args': ()
     },
+    'dequeue_upgrades': {
+        'task': 'sitesmanagement.cronjobs.dequeue_upgrades',
+        'schedule': timedelta(minutes=30),
+        'args': ()
+    },
 }
 
 MIDDLEWARE_CLASSES += (

--- a/mws/sitesmanagement/cronjobs.py
+++ b/mws/sitesmanagement/cronjobs.py
@@ -20,6 +20,7 @@ from django.core.urlresolvers import reverse
 from apimws.utils import preallocate_new_site
 from apimws.ansible import launch_ansible
 from apimws.models import QueueEntry
+from apimws.vm import clone_vm_api_call
 from sitesmanagement.models import Billing, Site, Service, VirtualMachine, DomainName, ServerType
 
 

--- a/mws/sitesmanagement/cronjobs.py
+++ b/mws/sitesmanagement/cronjobs.py
@@ -393,8 +393,8 @@ def send_reminder_delete_upgraded():
                      "old server has not been deleted yet. As the number of test servers the "
                      "MWS can support is limited, this may be blocking others from upgrading.\n"
                      "If you're happy with the new server, please delete the old one by "
-                     "visiting\n\nhttps://panel.mws3.csx.cam.ac.uk%s\n\nand clicking the "
-                     "'Delete the test server' button.\n\nThanks,\nMWS Support\n" % (conf_url),
+                     "visiting\n\n%s%s\n\nand clicking the "
+                     "'Delete the test server' button.\n\nThanks,\nMWS Support\n" % (settings.MAIN_DOMAIN, conf_url),
                 from_email="Managed Web Service Support <%s>"
                            % getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk'),
                 to=[site.email],
@@ -412,6 +412,7 @@ def dequeue_upgrades():
     if pending_upgrades < settings.MAX_PENDING_UPGRADES:
         queue_entry = QueueEntry.objects.first()
         if queue_entry is not None:
+            conf_url = reverse('sitesmanagement.views.service_settings', kwargs={'service_id': queue_entry.site.test_service.pk})
             clone_vm_api_call(queue_entry.site)
             EmailMessage(
                 subject="Test server for %s creating" % (queue_entry.site.name, ),
@@ -419,8 +420,8 @@ def dequeue_upgrades():
                      "This is to let you know that the test server requested for your site\n\n"
                      "'%s'\n\nis currently being created. Please allow a few minutes for this to complete. "
                      "You will be able to access and verify your websites on the test server by visiting\n\n"
-                     "%s/settings/%d\n\n"
-                     "Kind regards,\nMWS Support" % (queue_entry.site.name, settings.MAIN_DOMAIN, service.pk ),
+                     "%s%s\n\n"
+                     "Kind regards,\nMWS Support" % (queue_entry.site.name, settings.MAIN_DOMAIN, conf_url ),
                 from_email="Managed Web Service Support <%s>"
                            % getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk'),
                 to=[queue_entry.site.email],

--- a/mws/sitesmanagement/cronjobs.py
+++ b/mws/sitesmanagement/cronjobs.py
@@ -19,7 +19,8 @@ from django.core.urlresolvers import reverse
 
 from apimws.utils import preallocate_new_site
 from apimws.ansible import launch_ansible
-from sitesmanagement.models import Billing, Site, VirtualMachine, DomainName, ServerType
+from apimws.models import QueueEntry
+from sitesmanagement.models import Billing, Site, Service, VirtualMachine, DomainName, ServerType
 
 
 LOGGER = logging.getLogger('mws')
@@ -398,3 +399,30 @@ def send_reminder_delete_upgraded():
                 to=[site.email],
                 headers={'Return-Path': getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk')}
             ).send()
+
+
+@shared_task(base=ScheduledTaskWithFailure)
+def dequeue_upgrades():
+    '''
+    Create a test server for a site popped off the upgrade queue and notify
+    site administrators.
+    '''
+    pending_upgrades = len([x for x in Service.objects.filter(type='test').prefetch_related('virtual_machines') if x.active])
+    if pending_upgrades < settings.MAX_PENDING_UPGRADES:
+        queue_entry = QueueEntry.objects.first()
+        if queue_entry is not None:
+            clone_vm_api_call(queue_entry.site)
+            EmailMessage(
+                subject="Test server for %s creating" % (queue_entry.site.name, ),
+                body="Dear MWS Administrator,\n\n"
+                     "This is to let you know that the test server requested for your site\n\n"
+                     "'%s'\n\nis currently being created. Please allow a few minutes for this to complete. "
+                     "You will be able to access and verify your websites on the test server by visiting\n\n"
+                     "%s/settings/%d\n\n"
+                     "Kind regards,\nMWS Support" % (queue_entry.site.name, settings.MAIN_DOMAIN, service.pk ),
+                from_email="Managed Web Service Support <%s>"
+                           % getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk'),
+                to=[queue_entry.site.email],
+                headers={'Return-Path': getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk')}
+            ).send()
+            queue_entry.delete()

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -161,28 +161,6 @@ def delete_vm(request, service_id):
     if request.method == 'POST':
         for vm in service.virtual_machines.all():
             vm.delete()
-        if not service.primary:
-            # delete this site's queue entry if exists to avoid stale entries
-            if hasattr(site, 'queueentry'):
-                site.queueentry.delete()
-            # get, process and delete next queue entry
-            queue_entry = QueueEntry.objects.first()
-            if queue_entry is not None:
-                clone_vm_api_call(queue_entry.site)
-                EmailMessage(
-                    subject="Test server for %s creating" % (queue_entry.site.name, ),
-                    body="Dear MWS Administrator,\n\n"
-                         "This is to let you know that the test server requested for your site\n\n"
-                         "'%s'\n\nis currently being created. Please allow a few minutes for this to complete. "
-                         "You will be able to access and verify your websites on the test server by visiting\n\n"
-                         "%s/settings/%d\n\n"
-                         "Kind regards,\nMWS Support" % (queue_entry.site.name, settings.MAIN_DOMAIN, service.pk ),
-                    from_email="Managed Web Service Support <%s>"
-                               % getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk'),
-                    to=[queue_entry.site.email],
-                    headers={'Return-Path': getattr(settings, 'EMAIL_MWS3_SUPPORT', 'mws-support@uis.cam.ac.uk')}
-                ).send()
-                queue_entry.delete()
         return redirect(site)
 
     return HttpResponseForbidden()


### PR DESCRIPTION
This moves checking the upgrade queue and creating VMs for pending upgrades from when deleting a VM to a separate cronjob, invoked every 30 minutes, creating one instance every 30 minutes. This is so that we can work away the backlog of VMs that would otherwise not get purged from the queue.