### PR TITLE
report service status individually

### DIFF
--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -116,7 +116,7 @@ def service_status(request, service_id):
     if site is None:
         return HttpResponseForbidden()
 
-    if not site.production_service.is_ready or not site.test_service.is_ready:
+    if not (site.production_service.is_ready or site.test_service.is_ready):
         status = 'busy'
     elif not site.production_service.is_ready:
         status = 'prod'

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -116,10 +116,15 @@ def service_status(request, service_id):
     if site is None:
         return HttpResponseForbidden()
 
-    if service.is_ready:
-        return HttpResponse(json.dumps({'status': 'ready'}), content_type='application/json')
+    if site.production_service.is_busy and site.test_service.is_busy:
+        status = 'busy'
+    elif site.production_service.is_busy:
+        status = 'prod'
+    elif site.test_service.is_busy:
+        status = 'test'
     else:
-        return HttpResponse(json.dumps({'status': 'busy'}), content_type='application/json')
+        status = 'ready'
+    return HttpResponse(json.dumps({'status': status}), content_type='application/json')
 
 
 @login_required

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -116,7 +116,7 @@ def service_status(request, service_id):
     if site is None:
         return HttpResponseForbidden()
 
-    if not (site.production_service.is_ready or site.test_service.is_ready):
+    if not site.production_service.is_ready or not site.test_service.is_ready:
         status = 'busy'
     elif not site.production_service.is_ready:
         status = 'prod'

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -116,11 +116,11 @@ def service_status(request, service_id):
     if site is None:
         return HttpResponseForbidden()
 
-    if site.production_service.is_busy and site.test_service.is_busy:
+    if not (site.production_service.is_ready or site.test_service.is_ready):
         status = 'busy'
-    elif site.production_service.is_busy:
+    elif not site.production_service.is_ready:
         status = 'prod'
-    elif site.test_service.is_busy:
+    elif not site.test_service.is_ready:
         status = 'test'
     else:
         status = 'ready'

--- a/mws/templates/project-light/campl-mws.html
+++ b/mws/templates/project-light/campl-mws.html
@@ -71,8 +71,12 @@
                                     success: function(data, textStatus, jqXHR){
                                         if (data['status'] == 'ready') {
                                             $("#site_status").text("Your server is ready").css("background-color", "#0F8E00");
+                                        } else if (data['status'] == 'test') {
+                                            $("#site_status").text("Your test server is being configured").css("background-color", "#A09B00");
+                                        } else if (data['status'] == 'prod') {
+                                            $("#site_status").text("Your production server is being configured").css("background-color", "#A09B00");
                                         } else if (data['status'] == 'busy') {
-                                            $("#site_status").text("Your server is being configured").css("background-color", "#A09B00");
+                                            $("#site_status").text("Both your servers are being configured").css("background-color", "#A09B00");
                                         } else {
                                             $("#site_status").text("Error while checking status of your server").css("background-color", "#920101");
                                         }


### PR DESCRIPTION
This PR changes the way site business is reported to allow users to determine which services are being configured at the moment. Fixes #223 