### PR TITLE
WIP: Remove --initial flag

### DIFF
--- a/mws/apimws/views.py
+++ b/mws/apimws/views.py
@@ -137,7 +137,7 @@ def post_installation(request):
                 raise Exception("The service wasn't in the OS installation process")  # TODO raise custom exception
             service.status = 'postinstall'
             service.save()
-            post_installOS.apply_async((service), countdown=180)
+            post_installOS.apply_async((service,), countdown=180)
             # Wait 180 seconds before launching ansible, this will allow the machine have time to complete the reboot
             return HttpResponse()
 

--- a/mws/sitesmanagement/views/others.py
+++ b/mws/sitesmanagement/views/others.py
@@ -417,6 +417,6 @@ def resync(request, site_id):
         return redirect(site)
 
     if request.method == 'POST':
-        post_installOS.delay(site.test_service, initial=False)
+        post_installOS.delay(site.test_service)
     messages.info(request, 'The filesystem started to synchronise')
     return redirect(site)


### PR DESCRIPTION
This removes the initial clone flag and is in tandem with the WIP changes to clonestorage.py in mws-ansible.