### PR TITLE
make post_installOS run Ansible

### DIFF
--- a/mws/apimws/views.py
+++ b/mws/apimws/views.py
@@ -103,6 +103,8 @@ def confirm_email(request, ec_id, token):
 @shared_task(base=AnsibleTaskWithFailure, default_retry_delay=120, max_retries=2)
 def post_installOS(service):
     if service.type == 'test':
+        service.status = 'ansible'
+        service.save()
         command = ["userv", "mws-admin", "mws_clone",
                    service.site.production_service.virtual_machines.first().name,
                    service.site.test_service.virtual_machines.first().name]


### PR DESCRIPTION
`launch_ansible_async` only does its magic if the service's status is not 'ready', and the test service is in a 'ready' state when users initiate copying the filesystem contents, so make `post_installOS` set the status to `ansible`.